### PR TITLE
fix: add primary_branch to update_manager section to verify branch

### DIFF
--- a/klipper/moonraker_update.txt
+++ b/klipper/moonraker_update.txt
@@ -2,4 +2,5 @@
 type: git_repo
 path: ~/nevermore-controller
 origin: https://github.com/sanaahamel/nevermore-controller.git
+primary_branch: main
 is_system_service: False


### PR DESCRIPTION
This PR fix this info in the update_manager:
![Bildschirmfoto 2023-08-02 um 20 25 09](https://github.com/SanaaHamel/nevermore-controller/assets/8167632/f1db99ba-c0b1-44f6-9e7e-920cb9ac9ba4)
