### PR TITLE
Handle more klippy events & add debug logs

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -869,6 +869,10 @@ serial: <device path>
 # expected mean, but not the expected variance.
 #sensors_voc_expected_variance_independent: false
 
+# Enable debug logs of serial / ble connection
+# This option is disabled by default, only enable if you experience connection issues
+# enable_debug_logs: true
+
 
 # MOSTLY OBSOLETE.
 # Mainsail 2.7.1+ and Fluidd 1.31.0+ both have dedicated support for Nevermores.

--- a/klipper/nevermore.py
+++ b/klipper/nevermore.py
@@ -1019,9 +1019,7 @@ class Nevermore:
             self.send_printing_state_commands(printing)
 
     def _handle_shutdown(self):
-        if self._interface.connected:
-            self.send_printing_state_commands(False)  # release fan control & calibration
-
+        self.send_printing_state_commands(False)  # release fan control & calibration
         self._interface.disconnect()
 
     def _timer_vent_servo_release(self, eventtime: float) -> None:

--- a/klipper/nevermore.py
+++ b/klipper/nevermore.py
@@ -694,7 +694,7 @@ class NevermoreSerial(NevermoreBackground):
                 await self._worker_using(self._transport)
 
             except NevermoreSerialException as e:
-                self.log.debug(e, exc_info=e)
+                self.log.exception(e)
 
             except Exception as e:
                 # common IO failure, USB likely got pulled


### PR DESCRIPTION
Hello @SanaaHamel,

First of all, thank you for this amazing software !

Not related to the software but I had issues with my usb serial connection because of bad wire crimping, usb disconnections were not detected by os. What I discovered is that data+ disconnections trigger correctly but data- aren't detected by the os or anywhere. I changed by wire by a usb cable and all those problems went away.

But since I had issues I thought maybe I can use those usb issues to catch some unusual / unhandled errors. So I started with adding a bunch of debug log.

In the end the main changes were to improve the dispose of the serial connection and the handling of a few more klippy events for firmware restart / service restart.

I understand this is quite a big change, and don't hesitate to make comments on the changes you don't like

