### PR TITLE
Update LVGL repo URL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ FetchContent_Declare(
 )
 FetchContent_Declare(
   lvgl
-  GIT_REPOSITORY git@github.com:lvgl/lvgl.git
+  GIT_REPOSITORY https://github.com/lvgl/lvgl.git
   GIT_TAG release/v8.3
   GIT_SHALLOW ON
 )


### PR DESCRIPTION
Use HTTPS over SSH which probably isn't available unless someone already setup key pairs.