### PR TITLE
Fallback to AHT2x setup when AHT1x setup fail

### DIFF
--- a/src/sensors/ahtxx.cpp
+++ b/src/sensors/ahtxx.cpp
@@ -72,7 +72,9 @@ struct AHTxxSensor final : SensorPeriodicEnvI2C<Reg, "AHTxx"> {
     using SensorPeriodicEnvI2C::SensorPeriodicEnvI2C;
 
     bool setup() {  // NOLINT(readability-make-member-function-const)
-        if (!i2c.write(Reg::Init_1x, CMD_PAYLOAD_INIT)) return false;
+        if (!i2c.write(Reg::Init_1x, CMD_PAYLOAD_INIT))
+            if (!i2c.write(Reg::Init_2x, CMD_PAYLOAD_INIT))
+                return false;
 
         task_delay<DELAY_KLIPPER_INIT>();
         return true;


### PR DESCRIPTION
Could not get AHT20 sensor to init for my new build of StealthMax (using AHT20 + SGP40 sensors) so I did some debugging knowing the sensor works on klipper.

Notice the AHT2x init was defined but not used anywhere so I added a fallback/retry for the setup using the AHT2x init only when AHT1x init fail. This fixed the issue and my AHT20 sensor start working.

Here is the debug log before my change. You can see AHT20 is failing to init.

```
[2026-02-05 19:08:52.463] scanning for sensors...
[2026-02-05 19:08:52.470] ERR - [I2C0 0x15] CST816S - read-write failed; reg=0xa7 len=1 result=-2
[2026-02-05 19:08:52.471] ERR - [I2C1 0x15] CST816S - read-write failed; reg=0xa7 len=1 result=-2
[2026-02-05 19:08:52.477] ERR - [I2C0 0x38] AHTxx - write failed; len=3 result=1
[2026-02-05 19:08:52.482] ERR - [I2C0 0x39] AHTxx - write failed; len=3 result=-2
[2026-02-05 19:08:52.487] ERR - [I2C0 0x76] BME280 - read-write failed; reg=0xd0 len=1 result=-2
[2026-02-05 19:08:52.493] ERR - [I2C0 0x77] BME280 - read-write failed; reg=0xd0 len=1 result=-2
[2026-02-05 19:08:52.499] ERR - [I2C0 0x76] BME68x - read-write failed; reg=0xd0 len=1 result=-2
[2026-02-05 19:08:52.505] ERR - [I2C0 0x77] BME68x - read-write failed; reg=0xd0 len=1 result=-2
[2026-02-05 19:08:52.512] ERR - [I2C0 0x76] BMP280 - read-write failed; reg=0xd0 len=1 result=-2
[2026-02-05 19:08:52.527] ERR - [I2C0 0x77] BMP280 - read-write failed; reg=0xd0 len=1 result=-2
[2026-02-05 19:08:52.542] ERR - [I2C0 0x52] ENS16x - write failed; len=2 result=-2
[2026-02-05 19:08:52.546] ERR - [I2C0 0x53] ENS16x - write failed; len=2 result=-2
[2026-02-05 19:08:52.551] ERR - [I2C0 0x40] HTU2xD - write failed; len=1 result=-2
[2026-02-05 19:08:52.556] ERR - [I2C0 0x58] SGP30 - write failed; len=2 result=-2
[2026-02-05 19:08:52.561] sensor found: SGP40
[2026-02-05 19:08:52.566] ERR - [I2C0 0x44] SHT4x - write failed; len=1 result=-2
[2026-02-05 19:08:52.571] ERR - [I2C0 0x45] SHT4x - write failed; len=1 result=-2
[2026-02-05 19:08:52.576] ERR - [I2C0 0x46] SHT4x - write failed; len=1 result=-2
[2026-02-05 19:08:52.581] ERR - [I2C0 0x32] ZMOD4410 - read-write failed; reg=0xb7 len=1 result=-2
[2026-02-05 19:08:52.587] ERR - [I2C1 0x38] AHTxx - write failed; len=3 result=1
[2026-02-05 19:08:52.592] ERR - [I2C1 0x39] AHTxx - write failed; len=3 result=-2
[2026-02-05 19:08:52.597] ERR - [I2C1 0x76] BME280 - read-write failed; reg=0xd0 len=1 result=-2
[2026-02-05 19:08:52.603] ERR - [I2C1 0x77] BME280 - read-write failed; reg=0xd0 len=1 result=-2
[2026-02-05 19:08:52.609] ERR - [I2C1 0x76] BME68x - read-write failed; reg=0xd0 len=1 result=-2
[2026-02-05 19:08:52.616] ERR - [I2C1 0x77] BME68x - read-write failed; reg=0xd0 len=1 result=-2
[2026-02-05 19:08:52.622] ERR - [I2C1 0x76] BMP280 - read-write failed; reg=0xd0 len=1 result=-2
[2026-02-05 19:08:52.637] ERR - [I2C1 0x77] BMP280 - read-write failed; reg=0xd0 len=1 result=-2
[2026-02-05 19:08:52.652] ERR - [I2C1 0x52] ENS16x - write failed; len=2 result=-2
[2026-02-05 19:08:52.656] ERR - [I2C1 0x53] ENS16x - write failed; len=2 result=-2
[2026-02-05 19:08:52.661] ERR - [I2C1 0x40] HTU2xD - write failed; len=1 result=-2
[2026-02-05 19:08:52.666] ERR - [I2C1 0x58] SGP30 - write failed; len=2 result=-2
[2026-02-05 19:08:52.671] sensor found: SGP40
[2026-02-05 19:08:52.676] ERR - [I2C1 0x44] SHT4x - write failed; len=1 result=-2
[2026-02-05 19:08:52.681] ERR - [I2C1 0x45] SHT4x - write failed; len=1 result=-2
[2026-02-05 19:08:52.686] ERR - [I2C1 0x46] SHT4x - write failed; len=1 result=-2
[2026-02-05 19:08:52.691] ERR - [I2C1 0x32] ZMOD4410 - read-write failed; reg=0xb7 len=1 result=-2
[2026-02-05 19:08:52.705] sensor scan complete
```

Here is the log after the change showing the AHT20 sensor found (and working):
```
[2026-02-06 18:40:09.764] scanning for sensors...
[2026-02-06 18:40:09.766] ERR - [I2C0 0x15] CST816S - read-write failed; reg=0xa7 len=1 result=-2
[2026-02-06 18:40:09.772] ERR - [I2C1 0x15] CST816S - read-write failed; reg=0xa7 len=1 result=-2
[2026-02-06 18:40:09.778] ERR - [I2C0 0x38] AHTxx - write failed; len=3 result=1
[2026-02-06 18:40:09.881] sensor found: AHTxx
[2026-02-06 18:40:09.882] ERR - [I2C0 0x76] BME280 - read-write failed; reg=0xd0 len=1 result=-2
[2026-02-06 18:40:09.889] ERR - [I2C0 0x77] BME280 - read-write failed; reg=0xd0 len=1 result=-2
[2026-02-06 18:40:09.895] ERR - [I2C0 0x76] BME68x - read-write failed; reg=0xd0 len=1 result=-2
[2026-02-06 18:40:09.901] ERR - [I2C0 0x77] BME68x - read-write failed; reg=0xd0 len=1 result=-2
[2026-02-06 18:40:09.907] ERR - [I2C0 0x76] BMP280 - read-write failed; reg=0xd0 len=1 result=-2
[2026-02-06 18:40:09.922] ERR - [I2C0 0x77] BMP280 - read-write failed; reg=0xd0 len=1 result=-2
[2026-02-06 18:40:09.935] ERR - [I2C0 0x52] ENS16x - write failed; len=2 result=-2
[2026-02-06 18:40:09.940] ERR - [I2C0 0x53] ENS16x - write failed; len=2 result=-2
[2026-02-06 18:40:09.945] ERR - [I2C0 0x40] HTU2xD - write failed; len=1 result=-2
[2026-02-06 18:40:09.950] ERR - [I2C0 0x58] SGP30 - write failed; len=2 result=-2
[2026-02-06 18:40:10.273] sensor found: SGP40
[2026-02-06 18:40:10.275] ERR - [I2C0 0x44] SHT4x - write failed; len=1 result=-2
[2026-02-06 18:40:10.280] ERR - [I2C0 0x45] SHT4x - write failed; len=1 result=-2
[2026-02-06 18:40:10.284] ERR - [I2C0 0x46] SHT4x - write failed; len=1 result=-2
[2026-02-06 18:40:10.290] ERR - [I2C0 0x32] ZMOD4410 - read-write failed; reg=0xb7 len=1 result=-2
[2026-02-06 18:40:10.296] ERR - [I2C1 0x38] AHTxx - write failed; len=3 result=1
[2026-02-06 18:40:10.299] sensor found: AHTxx
[2026-02-06 18:40:10.300] ERR - [I2C1 0x76] BME280 - read-write failed; reg=0xd0 len=1 result=-2
[2026-02-06 18:40:10.306] ERR - [I2C1 0x77] BME280 - read-write failed; reg=0xd0 len=1 result=-2
[2026-02-06 18:40:10.312] ERR - [I2C1 0x76] BME68x - read-write failed; reg=0xd0 len=1 result=-2
[2026-02-06 18:40:10.318] ERR - [I2C1 0x77] BME68x - read-write failed; reg=0xd0 len=1 result=-2
[2026-02-06 18:40:10.325] ERR - [I2C1 0x76] BMP280 - read-write failed; reg=0xd0 len=1 result=-2
[2026-02-06 18:40:10.339] ERR - [I2C1 0x77] BMP280 - read-write failed; reg=0xd0 len=1 result=-2
[2026-02-06 18:40:10.353] ERR - [I2C1 0x52] ENS16x - write failed; len=2 result=-2
[2026-02-06 18:40:10.357] ERR - [I2C1 0x53] ENS16x - write failed; len=2 result=-2
[2026-02-06 18:40:10.362] ERR - [I2C1 0x40] HTU2xD - write failed; len=1 result=-2
[2026-02-06 18:40:10.367] ERR - [I2C1 0x58] SGP30 - write failed; len=2 result=-2
[2026-02-06 18:40:10.690] sensor found: SGP40
[2026-02-06 18:40:10.692] ERR - [I2C1 0x44] SHT4x - write failed; len=1 result=-2
[2026-02-06 18:40:10.697] ERR - [I2C1 0x45] SHT4x - write failed; len=1 result=-2
[2026-02-06 18:40:10.712] ERR - [I2C1 0x46] SHT4x - write failed; len=1 result=-2
[2026-02-06 18:40:10.707] ERR - [I2C1 0x32] ZMOD4410 - read-write failed; reg=0xb7 len=1 result=-2
[2026-02-06 18:40:10.713] sensor scan complete
```